### PR TITLE
test-bot: Disable --recursive for Linuxbrew

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -504,7 +504,8 @@ module Homebrew
     def formula(formula_name)
       @category = "#{__method__}.#{formula_name}"
 
-      test "brew", "uses", "--recursive", formula_name
+      args = ["--recursive"] unless OS.linux?
+      test "brew", "uses", *args, formula_name
 
       formula = Formulary.factory(formula_name)
 
@@ -601,7 +602,8 @@ module Homebrew
       build_dependencies = dependencies - runtime_dependencies
       unchanged_build_dependencies = build_dependencies - @formulae
 
-      dependents = Utils.popen_read("brew", "uses", "--recursive", formula_name).split("\n")
+      args = ["--recursive"] unless OS.linux?
+      dependents = Utils.popen_read("brew", "uses", *args, formula_name).split("\n")
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }
 


### PR DESCRIPTION
`brew uses --recursive` times out on CircleCI.
```
==> brew uses --recursive formula
..........
brew test-bot took more than 10 minutes since last output
```