### PR TITLE
test-bot: don't use git -C option

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -287,7 +287,7 @@ module Homebrew
       @repository = @tap ? @tap.path : HOMEBREW_REPOSITORY
       @skip_homebrew = options.fetch(:skip_homebrew, false)
 
-      if quiet_system "git", "-C", @repository.to_s, "rev-parse", "--verify", "-q", argument
+      if valid_git_ref?(argument)
         @hash = argument
       elsif url_match = argument.match(HOMEBREW_PULL_OR_COMMIT_URL_REGEX)
         @url = url_match[0]
@@ -300,6 +300,13 @@ module Homebrew
       @category = __method__
       @brewbot_root = Pathname.pwd + "brewbot"
       FileUtils.mkdir_p @brewbot_root
+    end
+
+    def valid_git_ref?(ref)
+      quiet_system "git",
+        "--git-dir", (@repository/".git").to_s,
+        "--work-tree", @repository.to_s,
+        "rev-parse", "--verify", "-q", ref
     end
 
     def no_args?


### PR DESCRIPTION
`-C` was only introduced in Git 1.8.5, which is older than the version of Git provided by some macOS versions and Linux distributions (including the CentOS 5 image used in homebrew-portable), so change the git command to use the equivalent options `--git-dir` and `--work-tree`, which have been around for much longer.

(See Homebrew/homebrew-test-bot#50.)