### PR TITLE
Install gcc on TravisCI for Linuxbrew

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -559,6 +559,11 @@ module Homebrew
         retry
       end
 
+      if OS.linux? && ENV["TRAVIS"]
+        installed_gcc = true
+        run_as_not_developer { test "brew", "install", "gcc" }
+      end
+
       begin
         deps.each do |dep|
           CompilerSelector.select_for(dep.to_formula)


### PR DESCRIPTION
Removing the dependencies of a formula before installing its bottle
can remove dependencies of gcc, particularly zlib, which can break the
subsequent brew test. Installing gcc before testing the formula
protects it and its dependencies from automatic removal.