### PR TITLE
Skip building devel versions on non-mac platforms

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -743,6 +743,7 @@ module Homebrew
       end
 
       if formula.devel && formula.stable? \
+         && OS.mac? \
          && !ARGV.include?("--HEAD") && !ARGV.include?("--fast") \
          && satisfied_requirements?(formula, :devel)
         test "brew", "fetch", "--retry", "--devel", *fetch_args


### PR DESCRIPTION
We're experiencing a lot of timeouts on CI, so this is a tradeoff.
While it means our support for devel versions will be inferior, that's
a tiny price to pay if it means we have fewer CI failures and faster
results.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>