### PR TITLE
Set diff_start_sha1 of a merge PR for Linxubrew

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -407,7 +407,11 @@ module Homebrew
         diff_end_sha1 = diff_start_sha1 = current_sha1
       end
 
-      diff_start_sha1 = git("merge-base", diff_start_sha1, diff_end_sha1).strip
+      if merge_commit? diff_end_sha1
+        diff_start_sha1 = git("rev-parse", "#{diff_end_sha1}^1").strip
+      else
+        diff_start_sha1 = git("merge-base", diff_start_sha1, diff_end_sha1).strip
+      end
 
       # Handle no arguments being passed on the command-line e.g. `brew test-bot`.
       if no_args?


### PR DESCRIPTION
This allows specifying a range of commits for the `test-bot` to test by setting the first parent of the merge PR appropriately.