### PR TITLE
Revert "Install gcc on TravisCI for Linuxbrew (#12)"

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -578,11 +578,6 @@ module Homebrew
         retry
       end
 
-      if OS.linux? && ENV["TRAVIS"]
-        installed_gcc = true
-        run_as_not_developer { test "brew", "install", "gcc" }
-      end
-
       begin
         deps.each do |dep|
           CompilerSelector.select_for(dep.to_formula)


### PR DESCRIPTION
This reverts commit e9ba0afc1533176bd235d10634613df82e24a431.

Do not install gcc on TravisCI.
GCC 5 is not ABI compatible with GCC 4.8, and
GCC 4.8 is used to build bottles for Linuxbrew.