### PR TITLE
LICENSE.txt: Use present instead of final year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2009-2016 Homebrew contributors.
+Copyright 2009-present Homebrew contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>