### PR TITLE
test-bot: Remove brew tests --official-cmd-taps

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -803,7 +803,6 @@ module Homebrew
 
         test "brew", "tests", "--no-compat"
         test "brew", "tests", "--generic"
-        test "brew", "tests", "--official-cmd-taps", *coverage_args
 
         if OS.mac?
           run_as_not_developer { test "brew", "tap", "caskroom/cask" }


### PR DESCRIPTION
This option no longer exists in brew tests.