### PR TITLE
cleanup_shared: Do not clean vendor/portable-ruby

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -823,7 +823,7 @@ module Homebrew
     def cleanup_shared
       cleanup_git_meta(HOMEBREW_REPOSITORY)
       git "gc", "--auto", "--force"
-      test "git", "clean", "-ffdx", "--exclude=Library/Taps"
+      test "git", "clean", "-ffdx", "--exclude=Library/Taps", "--exclude=Library/Homebrew/vendor/portable-ruby"
 
       Tap.names.each do |tap|
         next if tap == "homebrew/core"


### PR DESCRIPTION
Fix the error:
```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.sh: line 372: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin/ruby: No such file or directory
```