### PR TITLE
Disable update-test [Linux]

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -917,7 +917,7 @@ module Homebrew
         test "brew", "man", "--fail-if-changed"
 
         # test update from origin/master to current commit.
-        test "brew", "update-test"
+        test "brew", "update-test" unless OS.linux? # This test currently fails on Linux.
         # test update from origin/master to current tag.
         test "brew", "update-test", "--to-tag"
         # test no-op update from current commit (to current commit, a no-op).


### PR DESCRIPTION
It currently fails with this error:
```
Already up-to-date.
Error: brew update didn't update master!
Start commit:        8ccb999ac04fa9fcb4df521004be5eeff9fd8ba6
Expected end commit: e0881b851b3d6e40461060b1a9f2a69633b1ce7f
Actual end commit:   8ccb999ac04fa9fcb4df521004be5eeff9fd8ba6
==> FAILED
```