### PR TITLE
Disable --verbose on CircleCI [Linux]

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1417,8 +1417,9 @@ module Homebrew
 
     travis = !ENV["TRAVIS"].nil?
     circle = !ENV["CIRCLECI"].nil?
-    if travis || circle
-      ARGV << "--verbose" << "--ci-auto" << "--no-pull"
+    ARGV << "--ci-auto" << "--no-pull" if travis || circle
+    if travis
+      ARGV << "--verbose"
       ENV["HOMEBREW_VERBOSE_USING_DOTS"] = "1"
     end
 


### PR DESCRIPTION
Also disable `HOMEBREW_VERBOSE_USING_DOTS`.
The verbose info of `patchelf` is too verbose. Let's try disabling it. If CircleCI builds time out, try increasing `no_output_timeout` in `.circleci/config.yml`.
See https://circleci.com/docs/2.0/configuration-reference/#run