### PR TITLE
brew-test-bot.rb: disable recursive dependency test for Linuxbrew

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -719,8 +719,9 @@ module Homebrew
       build_dependencies = dependencies - runtime_or_test_dependencies
       @unchanged_build_dependencies = build_dependencies - @formulae
 
+      args = ["--recursive"] unless OS.linux?
       dependents =
-        Utils.popen_read("brew", "uses", "--recursive", formula_name)
+        Utils.popen_read("brew", "uses", *args, formula_name)
              .split("\n")
       dependents -= @formulae
       dependents = dependents.map { |d| Formulary.factory(d) }


### PR DESCRIPTION
Initially added in 52ab8589dc3a7face0b152923dcd908406372a87
Broken by 09356c21ce070a0b47af92669777c500c0240b67