### PR TITLE
testbottest: Fix URL of the tarball [Linux]

### DIFF
--- a/Formula/testbottest.rb
+++ b/Formula/testbottest.rb
@@ -1,7 +1,7 @@
 class Testbottest < Formula
   desc "Minimal C program and Makefile used for testing Homebrew"
   homepage "https://github.com/Homebrew/brew"
-  url "file://#{Tap.fetch("homebrew", "test-bot").formula_dir}/tarballs/testbottest-0.1.tbz"
+  url "file://#{Tap.fetch("linuxbrew", "test-bot").formula_dir}/tarballs/testbottest-0.1.tbz"
   sha256 "246c4839624d0b97338ce976100d56bd9331d9416e178eb0f74ef050c1dbdaad"
   head "https://github.com/Homebrew/homebrew-test-bot.git"
 


### PR DESCRIPTION
Fix the error:
```
Fetching testbottest from linuxbrew/test-bot
Downloading file:///home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-test-bot/Formula/tarballs/testbottest-0.1.tbz
Couldn't open file
```