### PR TITLE
Merge Homebrew/test-bot into Linuxbrew/test-bot

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -594,6 +594,8 @@ module Homebrew
     def setup
       @category = __method__
       return if @skip_setup
+      # install newer Git when needed
+      test "brew", "install", "git" if OS.mac? && MacOS.version < :sierra
       test "brew", "doctor"
       test "brew", "--env"
       test "brew", "config"

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -595,7 +595,10 @@ module Homebrew
       @category = __method__
       return if @skip_setup
       # install newer Git when needed
-      test "brew", "install", "git" if OS.mac? && MacOS.version < :sierra
+      if OS.mac? && MacOS.version < :sierra
+        test "brew", "install", "git"
+        ENV["HOMEBREW_FORCE_BREWED_GIT"] = "1"
+      end
       (Keg::TOP_LEVEL_DIRECTORIES + %w[opt]).each do |dir|
         FileUtils.mkdir_p HOMEBREW_PREFIX/dir
       end

--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -596,6 +596,9 @@ module Homebrew
       return if @skip_setup
       # install newer Git when needed
       test "brew", "install", "git" if OS.mac? && MacOS.version < :sierra
+      (Keg::TOP_LEVEL_DIRECTORIES + %w[opt]).each do |dir|
+        FileUtils.mkdir_p HOMEBREW_PREFIX/dir
+      end
       test "brew", "doctor"
       test "brew", "--env"
       test "brew", "config"


### PR DESCRIPTION
test-bot: create necessary top-level directories.

This ensures they have the right permissions and `brew doctor` doesn't get
upset.