### PR TITLE
Revert "Use ActiveSupport Hash#deep_merge"

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -1384,7 +1384,7 @@ module Homebrew
 
     json_files = Dir.glob("*.bottle.json")
     bottles_hash = json_files.reduce({}) do |hash, json_file|
-      hash.deep_merge(JSON.parse(IO.read(json_file)))
+      deep_merge_hashes hash, JSON.parse(IO.read(json_file))
     end
 
     if ARGV.include?("--dry-run")


### PR DESCRIPTION
This reverts commit d882cd477ce0e29a1bc2a23c253f6d395ca1b8c9.