### PR TITLE
brew-test-bot: Remove test bottle special case

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -801,8 +801,7 @@ module Homebrew
       end
 
       test "brew", "install", "--only-dependencies", bottle_filename
-      install_args = *("--force-bottle" if @test_default_formula)
-      test "brew", "install", *install_args, bottle_filename
+      test "brew", "install", bottle_filename
     end
 
     def install_bottled_dependent(dependent)


### PR DESCRIPTION
This was done for travis, as the bottle is not cellar :any.
A lot has changed since then, so this probabyl works now.