### PR TITLE
brew-test-bot: Enable devel testing again

### DIFF
--- a/cmd/brew-test-bot.rb
+++ b/cmd/brew-test-bot.rb
@@ -958,7 +958,6 @@ module Homebrew
 
       if formula.devel &&
          formula.stable? &&
-         OS.mac? &&
          !ARGV.include?("--HEAD") &&
          !ARGV.include?("--fast") &&
          satisfied_requirements?(formula, :devel)


### PR DESCRIPTION
Devel specs have all been removed from core anyway in release 1.8.2